### PR TITLE
Enhancement/78 bug nuke publish

### DIFF
--- a/quad_pyblish_module/plugins/nuke/publish/collect_licence_data.py
+++ b/quad_pyblish_module/plugins/nuke/publish/collect_licence_data.py
@@ -5,24 +5,26 @@ import os
 
 
 class CollectLicenceData(pyblish.api.InstancePlugin):
+
     """Collect Licence Data"""
 
     hosts = ["nuke"]
     label = "Collect Licence Data"
     order = pyblish.api.CollectorOrder + 0.4990
+    # TODO: avoid hardcoded path
+    rlm_path = "/prod/softprod/tools/linux/rlmutil"
 
-    def process(self, instance):
+    def get_available_licenses(self):
         """
         """
         # Define the command to run
-        # TODO: avoid hardcoded path
-        command = f'/prod/softprod/tools/linux/rlmutil rlmstat -c {os.environ["foundry_LICENSE"]} -avail'
+        avail_command = f'{self.rlm_path} rlmstat -c {os.environ["foundry_LICENSE"]} -avail'
 
         # Define the pattern for matching the number of available licenses for nuke_i
         pattern = r'nuke_i v\d+\.\d+ available: (\d+)'
 
         # Run the command and capture the output
-        result = subprocess.run(command, shell=True, stdout=subprocess.PIPE, text=True)
+        result = subprocess.run(avail_command, shell=True, stdout=subprocess.PIPE, text=True)
 
         # Use regex to find the match in the output
         match = re.search(pattern, result.stdout)
@@ -31,11 +33,40 @@ class CollectLicenceData(pyblish.api.InstancePlugin):
         if match:
             # Extract the number of available licenses
             available_licenses = int(match.group(1))
-            print(f"Available licenses for nuke_i: {available_licenses}")
         else:
-            print("No match found for nuke_i licenses.")
             return False
 
         if available_licenses == 0:
             return False
 
+        return True
+
+    def get_user_licenses(self):
+        # Define the pattern for matching user licenses for nuke_i
+        user_command = f'{self.rlm_path} rlmstat -c {os.environ["foundry_LICENSE"]} -u {os.environ["USER"]}'
+
+        user_pattern = r'nuke_i v\d+\.\d+: (\S+)@\S+ (\d+)/(\d+)'
+
+        # Run the command and capture the output
+        result = subprocess.run(user_command, shell=True, stdout=subprocess.PIPE, text=True)
+
+        # Use regex to find the match in the output
+        matches = re.findall(user_pattern, result.stdout)
+
+        # Check if any matches are found
+        if matches:
+            return True
+
+        return False
+
+    def process(self, instance):
+        # Check if user already have a licence
+        if self.get_user_licenses():
+            return True
+
+        # Check if user can get an available license
+        if self.get_available_licenses():
+            return True
+
+        # User can't publish
+        raise Exception("No available licence ! Can't publish")

--- a/quad_pyblish_module/plugins/nuke/publish/collect_licence_data.py
+++ b/quad_pyblish_module/plugins/nuke/publish/collect_licence_data.py
@@ -1,0 +1,41 @@
+import pyblish.api
+import subprocess
+import re
+import os
+
+
+class CollectLicenceData(pyblish.api.InstancePlugin):
+    """Collect Licence Data"""
+
+    hosts = ["nuke"]
+    label = "Collect Licence Data"
+    order = pyblish.api.CollectorOrder + 0.4990
+
+    def process(self, instance):
+        """
+        """
+        # Define the command to run
+        # TODO: avoid hardcoded path
+        command = f'/prod/softprod/tools/linux/rlmutil rlmstat -c {os.environ["foundry_LICENSE"]} -avail'
+
+        # Define the pattern for matching the number of available licenses for nuke_i
+        pattern = r'nuke_i v\d+\.\d+ available: (\d+)'
+
+        # Run the command and capture the output
+        result = subprocess.run(command, shell=True, stdout=subprocess.PIPE, text=True)
+
+        # Use regex to find the match in the output
+        match = re.search(pattern, result.stdout)
+
+        # Check if a match is found
+        if match:
+            # Extract the number of available licenses
+            available_licenses = int(match.group(1))
+            print(f"Available licenses for nuke_i: {available_licenses}")
+        else:
+            print("No match found for nuke_i licenses.")
+            return False
+
+        if available_licenses == 0:
+            return False
+


### PR DESCRIPTION
Add `CollectLicenceData` pre-publish class which check if nuke licences are available in order to execute the Publish process correctly.
If Licenses are not available, they will avoid the user to be blocked during the process instead, they will be block at the beginning.