### PR TITLE
#169: bugfixe: add missing 'enabled' attribute to allow deactivation through settings

### DIFF
--- a/quad_pyblish_module/plugins/tvpaint/create/create_json.py
+++ b/quad_pyblish_module/plugins/tvpaint/create/create_json.py
@@ -20,6 +20,7 @@ class TVPaintJsonCreator(Creator):
         )
         self.default_variant = plugin_settings["default_variant"]
         self.default_variants = plugin_settings["default_variants"]
+        self.enabled = plugin_settings["enabled"]
 
     def create(self, subset_name, instance_data, pre_create_data):
         existing_instance = None

--- a/quad_pyblish_module/plugins/tvpaint/create/create_playblast.py
+++ b/quad_pyblish_module/plugins/tvpaint/create/create_playblast.py
@@ -30,6 +30,7 @@ class TVPaintPlayblastCreator(TVPaintAutoCreator):
         self.default_variants =  plugin_settings["default_variants"]
         self.exports_types = ['camera', 'scene']
         self.export_type = self.exports_types[0]
+        self.enabled = plugin_settings["enabled"]
 
     def _create_new_instance(self):
         create_context = self.create_context
@@ -38,6 +39,7 @@ class TVPaintPlayblastCreator(TVPaintAutoCreator):
         asset_name = create_context.get_current_asset_name()
         task_name = create_context.get_current_task_name()
 
+        asset_doc = get_asset_by_name(project_name, asset_name)
         asset_doc = get_asset_by_name(project_name, asset_name)
         subset_name = self.get_subset_name(
             self.default_variant,

--- a/quad_pyblish_module/plugins/tvpaint/create/create_publish_layout.py
+++ b/quad_pyblish_module/plugins/tvpaint/create/create_publish_layout.py
@@ -31,6 +31,7 @@ class TVPaintPublishLayoutCreator(TVPaintAutoCreator):
         self.keep_layers_transparency = plugin_settings["keep_layers_transparency"]
         self.default_variant = plugin_settings["default_variant"]
         self.default_variants = plugin_settings["default_variants"]
+        self.enabled = plugin_settings["enabled"]
 
     def _create_new_instance(self):
         create_context = self.create_context


### PR DESCRIPTION
## Changelog Description
Add missing `enable` attribute set in custom tvPaint plugins. 

Linked issue : https://github.com/quadproduction/issues/issues/169
**This MR needs to be merge with this one : https://github.com/quadproduction/OpenPype/pull/599** 

## Additional info
This is the attribute which seems to be checked by OpenPype to display the plugins in the publish window. Without it, disabling or enabling these in settings have no effect.

## Testing notes:
1. Update state of any tvPaint plugin
2. Launch tvPaint
3. With OpenPype, open the publish menu
