### PR TITLE
Enhancement/181 enhancement make the extract psd optional on tvpaint

### DIFF
--- a/quad_pyblish_module/plugins/tvpaint/create/create_playblast.py
+++ b/quad_pyblish_module/plugins/tvpaint/create/create_playblast.py
@@ -9,7 +9,7 @@ from openpype.hosts.tvpaint.api.plugin import TVPaintAutoCreator
 
 
 class TVPaintPlayblastCreator(TVPaintAutoCreator):
-    families = ["render"]
+    family = ["render"]
     subset_template_family_filter = "playblast"
     identifier = "render.playblast"
     label = "Playblast"
@@ -28,6 +28,7 @@ class TVPaintPlayblastCreator(TVPaintAutoCreator):
         self.active_on_create = plugin_settings["active_on_create"]
         self.default_variant = plugin_settings["default_variant"]
         self.default_variants =  plugin_settings["default_variants"]
+        self.extract_psd = plugin_settings["extract_psd"]
         self.exports_types = ['camera', 'scene']
         self.export_type = self.exports_types[0]
 
@@ -120,6 +121,11 @@ class TVPaintPlayblastCreator(TVPaintAutoCreator):
                 "mark_for_review",
                 label="Review by default",
                 default=self.mark_for_review
+            ),
+            BoolDef(
+                "extract_psd",
+                label="Extract PSD",
+                default=self.extract_psd
             ),
             EnumDef(
                 "export_type",

--- a/quad_pyblish_module/plugins/tvpaint/create/create_playblast.py
+++ b/quad_pyblish_module/plugins/tvpaint/create/create_playblast.py
@@ -9,7 +9,7 @@ from openpype.hosts.tvpaint.api.plugin import TVPaintAutoCreator
 
 
 class TVPaintPlayblastCreator(TVPaintAutoCreator):
-    family = ["render"]
+    families = ["render"]
     subset_template_family_filter = "playblast"
     identifier = "render.playblast"
     label = "Playblast"

--- a/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
+++ b/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
@@ -22,6 +22,9 @@ class ExtractPsd(pyblish.api.InstancePlugin):
         'ExtractPsd']['enabled']
 
     def process(self, instance):
+        if not instance.data["creator_attributes"].get("extract_psd", self.enabled):
+            return
+
         george_script_lines = []
         repres = instance.data.get("representations")
         if not repres:

--- a/quad_pyblish_module/settings/defaults/project_settings.json
+++ b/quad_pyblish_module/settings/defaults/project_settings.json
@@ -22,6 +22,7 @@
                     "enabled": true,
                     "active_on_create": true,
                     "mark_for_review": true,
+                    "extract_psd": false,
                     "default_variant": "Main",
                     "default_variants": []
                 },

--- a/quad_pyblish_module/settings/schemas/project_schemas/tvpaint.json
+++ b/quad_pyblish_module/settings/schemas/project_schemas/tvpaint.json
@@ -111,6 +111,11 @@
                                 "label": "Review by default"
                             },
                             {
+                                "type": "boolean",
+                                "key": "extract_psd",
+                                "label": "Extract PSD by default"
+                            },
+                            {
                                 "type": "text",
                                 "key": "default_variant",
                                 "label": "Default variant"


### PR DESCRIPTION
## Changelog Description
Add option for enabling / disabling `.psd` extract for tvPaint's Playblast custom plugin.

Linked issue : https://github.com/quadproduction/issues/issues/181

## Additional info
Cases : 
- If the attribute is set to True, the process continues.
- If the attribute is set to False, the process is aborted.
- If the attribute is not found, it retrieves the plugin's inital attribute enabled and also checks its value as before.

## Testing notes:
1. Launch tvPaint publish
2. Launch Playblast with `Extract PSD` checked / unchecked
