### PR TITLE
Force render folder creation from Local

### DIFF
--- a/quad_pyblish_module/plugins/maya/publish/validate_render_folder_creation.py
+++ b/quad_pyblish_module/plugins/maya/publish/validate_render_folder_creation.py
@@ -1,0 +1,38 @@
+from pyblish import api
+from openpype.pipeline.publish import ValidateContentsOrder
+from openpype.pipeline.publish.lib import get_publish_template_name
+import os
+import copy
+
+
+class ValidateRenderFolderCreation(api.InstancePlugin):
+    """Validate Render Folder Creation"""
+
+    order = ValidateContentsOrder
+    hosts = ["maya"]
+    families = ["renderlayer", "renderlocal"]
+    label = "Validate Render Folder Creation"
+    optional = True
+
+    def process(self, instance):
+        """The aim is to create the publish folder directly from the user machine and
+        not from the renderfarm.
+
+        :param context: The Pyblish context.
+        :type context: pyblish.api.Context
+        """
+        # Get the context data
+        anatomy = instance.context.data["anatomy"]
+        template_data = copy.deepcopy(instance.data["anatomyData"])
+        # We force the family as 'render' (Check ValidatePublishDir() Plugin)
+        template_data["family"] = "render"
+        # Recover the publish template
+        publish_templates = anatomy.templates_obj["publish"]
+        # Generate the template
+        publish_folder = publish_templates["folder"].format_strict(template_data)
+        publish_folder = os.path.normpath(publish_folder)
+
+        self.log.debug("publishDir: \"{}\"".format(publish_folder))
+        # Force creation of the folder
+        if not os.path.exists(publish_folder):
+            os.makedirs(publish_folder)


### PR DESCRIPTION
In order to fix the permission issue on render folder , this script will force the creation of publish dir directly from the user local session instead of being created from the renderfarm.

Only works for 'renderlayer' and 'renderlocal' families.
Plugin is optionnal.

# TEST

1. Make your openpype custom plugins environment point on your custom repo
2. Open custom task which does not have 'render' folder, open maya, create renderlayer, make a publish
3. Check your 'render' folder permission