### PR TITLE
Enhancement/198 : enhancement toggle extract psd for layout posing export tvpaint

### DIFF
--- a/quad_pyblish_module/plugins/tvpaint/create/create_playblast.py
+++ b/quad_pyblish_module/plugins/tvpaint/create/create_playblast.py
@@ -54,7 +54,8 @@ class TVPaintPlayblastCreator(TVPaintAutoCreator):
             "variant": self.default_variant,
             "creator_attributes": {
                 "mark_for_review": self.mark_for_review,
-                "export_type": self.export_type
+                "export_type": self.export_type,
+                "self.extract_psd": self.extract_psd
             },
             "label": self._get_label(subset_name),
             "active": self.active_on_create

--- a/quad_pyblish_module/plugins/tvpaint/create/create_playblast.py
+++ b/quad_pyblish_module/plugins/tvpaint/create/create_playblast.py
@@ -55,7 +55,7 @@ class TVPaintPlayblastCreator(TVPaintAutoCreator):
             "creator_attributes": {
                 "mark_for_review": self.mark_for_review,
                 "export_type": self.export_type,
-                "self.extract_psd": self.extract_psd
+                "extract_psd": self.extract_psd
             },
             "label": self._get_label(subset_name),
             "active": self.active_on_create

--- a/quad_pyblish_module/plugins/tvpaint/create/create_publish_layout.py
+++ b/quad_pyblish_module/plugins/tvpaint/create/create_publish_layout.py
@@ -31,6 +31,7 @@ class TVPaintPublishLayoutCreator(TVPaintAutoCreator):
         self.keep_layers_transparency = plugin_settings["keep_layers_transparency"]
         self.default_variant = plugin_settings["default_variant"]
         self.default_variants = plugin_settings["default_variants"]
+        self.extract_psd = plugin_settings["extract_psd"]
         self.enabled = plugin_settings.get("enabled", True)
 
     def _create_new_instance(self):
@@ -54,7 +55,8 @@ class TVPaintPublishLayoutCreator(TVPaintAutoCreator):
             "variant": self.default_variant,
             "creator_attributes": {
                 "publish_sequence": self.publish_sequence,
-                "keep_layers_transparency": self.keep_layers_transparency
+                "keep_layers_transparency": self.keep_layers_transparency,
+                "extract_psd": self.extract_psd
             },
             "label": self._get_label(subset_name),
             "active": self.active_on_create
@@ -122,6 +124,11 @@ class TVPaintPublishLayoutCreator(TVPaintAutoCreator):
                 "keep_layers_transparency",
                 label="Keep Layers Transparency",
                 default=self.keep_layers_transparency
+            ),
+            BoolDef(
+                "extract_psd",
+                label="Extract PSD",
+                default=self.extract_psd
             ),
             BoolDef(
                 "publish_sequence",

--- a/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
+++ b/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
@@ -13,7 +13,7 @@ class ExtractPsd(pyblish.api.InstancePlugin):
     order = pyblish.api.ExtractorOrder + 0.02
     label = "Extract PSD"
     hosts = ["tvpaint"]
-    families = ["renderLayer", "review"]
+    families = ["renderLayer", "review", "render"]
 
     project_name = os.environ['AVALON_PROJECT']
     project_settings = get_project_settings(project_name)
@@ -22,7 +22,7 @@ class ExtractPsd(pyblish.api.InstancePlugin):
         'ExtractPsd']['enabled']
 
     def process(self, instance):
-        if not instance.data["creator_attributes"].get("extract_psd", self.enabled):
+        if not instance.data["creator_attributes"].get("extract_psd", False):
             return
 
         george_script_lines = []

--- a/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
+++ b/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
@@ -19,10 +19,13 @@ class ExtractPsd(pyblish.api.InstancePlugin):
     project_settings = get_project_settings(project_name)
 
     enabled = project_settings['fix_custom_settings']['tvpaint']['publish'][
-        'ExtractPsd']['enabled']
+        'ExtractPsd'].get('enabled')
 
     def process(self, instance):
-        if not instance.data["creator_attributes"].get("extract_psd", False):
+        if not self.enabled:
+            return
+
+        if not instance.data["creator_attributes"].get("extract_psd", self.enabled):
             return
 
         george_script_lines = []

--- a/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
+++ b/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
@@ -25,7 +25,7 @@ class ExtractPsd(pyblish.api.InstancePlugin):
         if not self.enabled:
             return
 
-        if not instance.data["creator_attributes"].get("extract_psd", self.enabled):
+        if not instance.data["creator_attributes"].get("extract_psd", False):
             return
 
         george_script_lines = []

--- a/quad_pyblish_module/settings/defaults/project_settings.json
+++ b/quad_pyblish_module/settings/defaults/project_settings.json
@@ -30,6 +30,7 @@
                     "enabled": true,
                     "active_on_create": true,
                     "keep_layers_transparency": true,
+                    "extract_psd": false,
                     "default_variant": "Main",
                     "default_variants": []
                 }

--- a/quad_pyblish_module/settings/schemas/project_schemas/tvpaint.json
+++ b/quad_pyblish_module/settings/schemas/project_schemas/tvpaint.json
@@ -20,10 +20,6 @@
                         "checkbox_key": "enabled",
                         "children": [
                             {
-                                "type": "label",
-                                "label": "<b>Warning :</b> this plugin is only available for subsets with an <i>Extract PSD</i> option."
-                            },
-                            {
                                 "type": "boolean",
                                 "key": "enabled",
                                 "label": "Enabled"

--- a/quad_pyblish_module/settings/schemas/project_schemas/tvpaint.json
+++ b/quad_pyblish_module/settings/schemas/project_schemas/tvpaint.json
@@ -13,11 +13,16 @@
                 "children": [
                     {
                         "type": "dict",
+                        "collapsible": true,
                         "key": "ExtractPsd",
                         "label": "Extract PSD",
-                        "is_group": false,
+                        "is_group": true,
                         "checkbox_key": "enabled",
                         "children": [
+                            {
+                                "type": "label",
+                                "label": "<b>Warning :</b> in order to enable this plugin, you also need to set an attribute <i>extract_psd</i> in your subset."
+                            },
                             {
                                 "type": "boolean",
                                 "key": "enabled",
@@ -151,6 +156,11 @@
                                 "type": "boolean",
                                 "key": "keep_layers_transparency",
                                 "label": "Keep Layers Transparency"
+                            },
+                            {
+                                "type": "boolean",
+                                "key": "extract_psd",
+                                "label": "Extract PSD by default"
                             },
                             {
                                 "type": "text",

--- a/quad_pyblish_module/settings/schemas/project_schemas/tvpaint.json
+++ b/quad_pyblish_module/settings/schemas/project_schemas/tvpaint.json
@@ -21,7 +21,7 @@
                         "children": [
                             {
                                 "type": "label",
-                                "label": "<b>Warning :</b> in order to enable this plugin, you also need to set an attribute <i>extract_psd</i> in your subset."
+                                "label": "<b>Warning :</b> this plugin is only available for subsets with an <i>Extract PSD</i> option."
                             },
                             {
                                 "type": "boolean",


### PR DESCRIPTION
## Changelog Description
Add `render` family in supported families for tvPaint `Extract PSD` plugin.
Also update or add toggle options for activating or deactivating the plugin for specific subsets (Publish Layout, Playblast)

**This MR needs to be merge with this one : https://github.com/quadproduction/OpenPype/pull/633**

## Additional notes

The subset `Extract PSD` now needs two elements to be correctly triggered : 
- The subset needs to be activated in the settings
- The subset which should extract `.psd` files must set an attribute called `extract_psd` in order to work correctly. If the attribute is not found, the subset `extract psd` will abort his process.

## Testing notes:
1. Open tvPaint
2. Launch a Scene render for any scene
3. Check for `.psd` file in publish folder.
