### PR TITLE
Fix ValidateRenderFolderCreation() template folder creation logic

### DIFF
--- a/quad_pyblish_module/plugins/maya/publish/validate_render_folder_creation.py
+++ b/quad_pyblish_module/plugins/maya/publish/validate_render_folder_creation.py
@@ -24,18 +24,19 @@ class ValidateRenderFolderCreation(api.InstancePlugin):
         template_data = copy.deepcopy(instance.data["anatomyData"])
         template_name = "render"
         anatomy = instance.context.data['anatomy']
-        # Build template attributes dict necessary to
-        template_attributes = [
+
+        # Additional template attributes necessary to retrieve the desired path
+        additional_template_attributes = [
             "originalBasename",
             "originalDirname",
             "colorspace",
             "version"
         ]
-        for template_attribute in template_attributes:
-            template_data[template_attribute] = ''
+        for template_attribute in additional_template_attributes:
+            template_data[template_attribute] = ""
 
         for key_attr, value_attr in instance.data.items():
-            if key_attr in template_attributes:
+            if key_attr in additional_template_attributes:
                 template_data[key_attr] = value_attr
 
         # Get the render template

--- a/quad_pyblish_module/plugins/maya/publish/validate_render_folder_creation.py
+++ b/quad_pyblish_module/plugins/maya/publish/validate_render_folder_creation.py
@@ -1,6 +1,5 @@
 from pyblish import api
 from openpype.pipeline.publish import ValidateContentsOrder
-from openpype.pipeline.publish.lib import get_publish_template_name
 import os
 import copy
 
@@ -22,17 +21,37 @@ class ValidateRenderFolderCreation(api.InstancePlugin):
         :type context: pyblish.api.Context
         """
         # Get the context data
-        anatomy = instance.context.data["anatomy"]
         template_data = copy.deepcopy(instance.data["anatomyData"])
-        # We force the family as 'render' (Check ValidatePublishDir() Plugin)
-        template_data["family"] = "render"
-        # Recover the publish template
-        publish_templates = anatomy.templates_obj["publish"]
-        # Generate the template
-        publish_folder = publish_templates["folder"].format_strict(template_data)
-        publish_folder = os.path.normpath(publish_folder)
+        template_name = "render"
+        anatomy = instance.context.data['anatomy']
+        # Build template attributes dict necessary to
+        template_attributes = [
+            "originalBasename",
+            "originalDirname",
+            "colorspace",
+            "version"
+        ]
+        for template_attribute in template_attributes:
+            template_data[template_attribute] = ''
 
-        self.log.debug("publishDir: \"{}\"".format(publish_folder))
-        # Force creation of the folder
-        if not os.path.exists(publish_folder):
+        for key_attr, value_attr in instance.data.items():
+            if key_attr in template_attributes:
+                template_data[key_attr] = value_attr
+
+        # Get the render template
+        template_data["family"] = 'render'
+        path_template_obj = anatomy.templates_obj[template_name]["folder"]
+        expected_files = instance.data['expectedFiles']
+        publish_folders = []
+        for expected_files_by_layer in expected_files:
+            for layer_name, filepaths in expected_files_by_layer.items():
+                # Increment renderlayer name in the subset
+                template_data["subset"] += '_{0}'.format(layer_name)
+                template_filled = path_template_obj.format_strict(template_data)
+                if not os.path.exists(template_filled):
+                    publish_folders.append(template_filled)
+
+        for publish_folder in publish_folders:
+            self.log.debug("publish directory: \"{}\"".format(publish_folder))
+            # Force creation of the folder
             os.makedirs(publish_folder)


### PR DESCRIPTION
I've changed the logic based on IntegrationAsset() logic (plugin which are executed in the farm).

Before the template was setted as 'publish' and not 'render' (recover from the Anatomy instance).
