### PR TITLE
Add trigger sync to avalon plugin for Hiero

### DIFF
--- a/quad_pyblish_module/plugins/hiero/publish/trigger_sync_to_avalon.py
+++ b/quad_pyblish_module/plugins/hiero/publish/trigger_sync_to_avalon.py
@@ -1,0 +1,38 @@
+import pyblish.api
+import ftrack_api
+
+class IntegrateTriggerSyncToAvalon(pyblish.api.ContextPlugin):
+    """ Triggers Avalon synchronization.
+    """
+
+    order = pyblish.api.IntegratorOrder + 10.2
+    label = "Trigger Sync To Avalon Action"
+    families = ["shot"]
+    hosts = ["hiero"]
+
+    def process(self, context):
+        # we do this only if the collect hierarchy is done
+        hierarchy_context = context.data.get("hierarchyContext")
+        if not hierarchy_context:
+            self.log.debug("Skipping {}".format(type(self).__name__))
+            return
+
+        session = context.data["ftrackSession"]
+
+        event_data = {
+            "actionIdentifier": "sync.to.avalon.server",
+            "project_name": context.data["projectEntity"]["name"],
+            "selection": [{
+                "entityId": context.data["projectEntity"]["data"]["ftrackId"],
+                "entityType": "show"
+            }],
+        }
+        session.event_hub.connect()
+        session.event_hub.publish(
+            ftrack_api.event.base.Event(
+                topic="ftrack.action.launch",
+                data=event_data,
+            ),
+            on_error="ignore"
+        )
+


### PR DESCRIPTION
We trigger the Sync to Avalon action at the end of the publish process, as it is not done automatically. This will update tools attributes on the created shots.

To test it, you should:
- Clone this repo and change OPENPYPE_CUSTOM_PLUGINS environment in local openpype settings. 
- Open Hiero in this context: project: TEST_OP2_PUB_23_7, shot: Editorial, task: confo
- Select the shot 904_0090 in timeline and publish (you can publish each shot just once) 
![image](https://github.com/quadproduction/openpype-custom-plugins/assets/68907585/69fdbaa4-7212-478d-85eb-afb15a17c0c1)

