### PR TITLE
#336: enhancement: use 'sceneMarkIn' value from OpenPype to determine frames to extract in extract_psd

### DIFF
--- a/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
+++ b/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
@@ -62,7 +62,7 @@ class ExtractPsd(pyblish.api.InstancePlugin):
             new_filenames = []
             for offset, filename in enumerate(files):
                 new_filename = Path(filename).stem
-                dst_filepath = Path(repre["stagingDir"], new_filename)
+                dst_filepath = Path(output_dir, new_filename)
                 new_filenames.append(new_filename + '.psd')
 
                 # george command to export psd files for each image

--- a/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
+++ b/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
@@ -55,18 +55,27 @@ class ExtractPsd(pyblish.api.InstancePlugin):
                 files = repre['files']
 
             new_filenames = []
-            for filename in files:
+            for offset, filename in enumerate(files):
                 new_filename = os.path.splitext(filename)[0]
                 dst_filepath = os.path.join(repre["stagingDir"], new_filename)
                 new_filenames.append(new_filename + '.psd')
+
+                #frame_start = self.get_frame_start(repre)
+                self.log.warning(instance.context.data["sceneMarkIn"])
+                self.log.warning(type(instance.context.data["sceneMarkIn"]))
 
                 # george command to export psd files for each image
                 george_script_lines.append(
                     "tv_clipsavestructure \"{}\" \"PSD\" \"image\" {}".format(
                         dst_filepath,
-                        int(new_filename) - 1
+                        int(instance.context.data["sceneMarkIn"]) + offset
                     )
                 )
+
+                self.log.warning("tv_clipsavestructure \"{}\" \"PSD\" \"image\" {}".format(
+                        dst_filepath,
+                        int(instance.context.data["sceneMarkIn"]) + offset
+                    ))
 
             # Convert list to str if there's only one item
             if len(new_filenames) == 1:

--- a/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
+++ b/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
@@ -60,10 +60,6 @@ class ExtractPsd(pyblish.api.InstancePlugin):
                 dst_filepath = os.path.join(repre["stagingDir"], new_filename)
                 new_filenames.append(new_filename + '.psd')
 
-                #frame_start = self.get_frame_start(repre)
-                self.log.warning(instance.context.data["sceneMarkIn"])
-                self.log.warning(type(instance.context.data["sceneMarkIn"]))
-
                 # george command to export psd files for each image
                 george_script_lines.append(
                     "tv_clipsavestructure \"{}\" \"PSD\" \"image\" {}".format(
@@ -71,11 +67,6 @@ class ExtractPsd(pyblish.api.InstancePlugin):
                         int(instance.context.data["sceneMarkIn"]) + offset
                     )
                 )
-
-                self.log.warning("tv_clipsavestructure \"{}\" \"PSD\" \"image\" {}".format(
-                        dst_filepath,
-                        int(instance.context.data["sceneMarkIn"]) + offset
-                    ))
 
             # Convert list to str if there's only one item
             if len(new_filenames) == 1:

--- a/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
+++ b/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
@@ -52,8 +52,6 @@ class ExtractPsd(pyblish.api.InstancePlugin):
                 json.dumps(repre, sort_keys=True, indent=4)
             ))
 
-            
-
             if not isinstance(repre['files'], list):
                 files = [repre['files']]
             else:

--- a/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
+++ b/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
@@ -22,6 +22,8 @@ class ExtractPsd(pyblish.api.InstancePlugin):
     enabled = project_settings['fix_custom_settings']['tvpaint']['publish'][
         'ExtractPsd'].get('enabled')
 
+    staging_dir_prefix = "tvpaint_export_json_psd_"
+
     def process(self, instance):
         if not self.enabled:
             return
@@ -36,12 +38,16 @@ class ExtractPsd(pyblish.api.InstancePlugin):
         
         scene_mark_in = int(instance.context.data["sceneMarkIn"])
         output_dir = instance.data.get("stagingDir")
-        if not output_dir or not os.path.exists(output_dir):
+
+        if output_dir:
+            # Only convert to a Path object if not None or empty
+            output_dir = Path(output_dir)
+
+        if not output_dir or not output_dir.exists():
             # Create temp folder if staging dir is not set
-            output_dir = (
-                tempfile.mkdtemp(prefix="tvpaint_export_json_psd_")
-            ).replace("\\", "/")
-            instance.data['stagingDir'] = output_dir
+            output_dir = Path(tempfile.mkdtemp(
+                prefix=self.staging_dir_prefix).replace("\\", "/"))
+            instance.data['stagingDir'] = output_dir.resolve()
 
         new_psd_repres = []
         for repre in repres:

--- a/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
+++ b/quad_pyblish_module/plugins/tvpaint/publish/extract_psd.py
@@ -66,7 +66,7 @@ class ExtractPsd(pyblish.api.InstancePlugin):
             new_filenames = []
             for offset, filename in enumerate(files):
                 new_filename = Path(filename).stem
-                dst_filepath = Path(output_dir, new_filename)
+                dst_filepath = output_dir.joinpath(new_filename)
                 new_filenames.append(new_filename + '.psd')
 
                 # george command to export psd files for each image


### PR DESCRIPTION
Use static value instead of parsing frame start from file name and use tv paint frame start as offset

fix quadproduction/issues#336