### PR TITLE
#346: bugfix: Resolution du bug de review Kitsu sur les layoutPosing …

### DIFF
--- a/quad_pyblish_module/plugins/common/publish/integrate_kitsu_sequence.py
+++ b/quad_pyblish_module/plugins/common/publish/integrate_kitsu_sequence.py
@@ -39,6 +39,11 @@ class IntegrateKitsuSequence(pyblish.api.InstancePlugin):
                 continue
 
             filesnames = representation.get("files")
+
+            #if only one frame is publish, transform representation["files"] into a list qith a single element
+            if type(filesnames) != list:
+                filesnames = [filesnames]
+
             if not filesnames:
                 self.log.warning("No files found following sequence extract.")
                 raise IndexError       


### PR DESCRIPTION
…d'une seule frame


Permet de pallier le bug de trop de publish sur kitsu en review car quand on publish une single frame, l'info interprété est une str 0001.png et non une liste comme attendue [0001.png].