### PR TITLE
#322: enhancement: add importer for images and videos in Blender

### DIFF
--- a/quad_pyblish_module/plugins/blender/load/import_image_as_reference.py
+++ b/quad_pyblish_module/plugins/blender/load/import_image_as_reference.py
@@ -20,8 +20,8 @@ class ImageReferenceLoader(plugin.AssetLoader):
     Stores the imported asset in an empty named after the asset.
     """
 
-    families = ["image", "render"]
-    representations = ["*"]
+    families = ["image", "render", "review"]
+    representations = ["jpg", "png"]
 
     label = "Load Image as Reference"
     icon = "code-fork"
@@ -39,18 +39,9 @@ class ImageReferenceLoader(plugin.AssetLoader):
             context: Full parenthood of representation to load
             options: Additional settings dictionary
         """
-        print('IMAGE LOADER')
-        print(context)
-        print(name)
-        print(namespace)
-        print(options)
+
         image_filepath = self.filepath_from_context(context)
         asset = context["asset"]["name"]
-        subset = context["subset"]["name"]
-        print('----')
-        print(image_filepath)
-        print(asset)
-        print(subset)
 
         imported_image = bpy.data.images.load(image_filepath)
         image_name = asset + '_null'

--- a/quad_pyblish_module/plugins/blender/load/import_image_as_reference.py
+++ b/quad_pyblish_module/plugins/blender/load/import_image_as_reference.py
@@ -1,0 +1,69 @@
+"""Load an asset in Blender from an Alembic file."""
+
+from typing import Dict, List, Optional
+
+import bpy
+
+from openpype.pipeline import (
+    get_representation_path,
+    AVALON_CONTAINER_ID,
+)
+from openpype.hosts.blender.api import plugin, lib
+from openpype.hosts.blender.api.pipeline import (
+    AVALON_CONTAINERS,
+    AVALON_PROPERTY,
+)
+
+class ImageReferenceLoader(plugin.AssetLoader):
+    """Load FBX models.
+
+    Stores the imported asset in an empty named after the asset.
+    """
+
+    families = ["image", "render"]
+    representations = ["*"]
+
+    label = "Load Image as Reference"
+    icon = "code-fork"
+    color = "orange"
+
+    def process_asset(
+        self, context: dict, name: str, namespace: Optional[str] = None,
+        options: Optional[Dict] = None
+    ) -> Optional[List]:
+    
+        """
+        Arguments:
+            name: Use pre-defined name
+            namespace: Use pre-defined namespace
+            context: Full parenthood of representation to load
+            options: Additional settings dictionary
+        """
+        print('IMAGE LOADER')
+        print(context)
+        print(name)
+        print(namespace)
+        print(options)
+        image_filepath = self.filepath_from_context(context)
+        asset = context["asset"]["name"]
+        subset = context["subset"]["name"]
+        print('----')
+        print(image_filepath)
+        print(asset)
+        print(subset)
+
+        imported_image = bpy.data.images.load(image_filepath)
+        image_name = asset + '_null'
+
+        empty = bpy.data.objects.new(image_name, None)
+        empty.empty_display_type = "IMAGE"
+    
+        ref_collection = bpy.data.collections.get("_REF")
+        if not ref_collection:
+            ref_collection = bpy.data.collections.new(name="_REF")
+            bpy.context.scene.collection.children.link(ref_collection)
+        ref_collection.objects.link(empty)
+
+        empty.data = imported_image
+
+        self.log.info(f"Image at path {imported_image.filepath} has been correctly loaded in scene as reference.")

--- a/quad_pyblish_module/plugins/blender/load/import_image_as_reference.py
+++ b/quad_pyblish_module/plugins/blender/load/import_image_as_reference.py
@@ -15,9 +15,9 @@ from openpype.hosts.blender.api.pipeline import (
 )
 
 class ImageReferenceLoader(plugin.AssetLoader):
-    """Load FBX models.
+    """Load Image in Blender as reference.
 
-    Stores the imported asset in an empty named after the asset.
+    Create image in empty and put it in _REF collection.
     """
 
     families = ["image", "render", "review"]

--- a/quad_pyblish_module/plugins/blender/load/import_image_in_camera.py
+++ b/quad_pyblish_module/plugins/blender/load/import_image_in_camera.py
@@ -17,9 +17,9 @@ from openpype.hosts.blender.api.pipeline import (
 )
 
 class ImageCameraLoader(plugin.AssetLoader):
-    """Load FBX models.
+    """Load Image in Blender as background in camera.
 
-    Stores the imported asset in an empty named after the asset.
+    Create background image for active camera and assign selected image.
     """
 
     families = ["image", "render", "review"]

--- a/quad_pyblish_module/plugins/blender/load/import_image_in_camera.py
+++ b/quad_pyblish_module/plugins/blender/load/import_image_in_camera.py
@@ -53,7 +53,8 @@ class ImageCameraLoader(plugin.AssetLoader):
             background = camera.data.background_images[0]
         except IndexError:
             background = camera.data.background_images.new()        
-        imported_image.source = 'SEQUENCE'
+        imported_image.source = 'FILE'
+        background.source = 'IMAGE'
         background.image = imported_image
 
         self.log.info(f"Image at path {imported_image.filepath} has been correctly loaded in scene as camera background.")

--- a/quad_pyblish_module/plugins/blender/load/import_image_in_camera.py
+++ b/quad_pyblish_module/plugins/blender/load/import_image_in_camera.py
@@ -1,0 +1,55 @@
+"""Load an asset in Blender from an Alembic file."""
+
+from pathlib import Path
+from pprint import pformat
+from typing import Dict, List, Optional
+
+import bpy
+
+from openpype.pipeline import (
+    get_representation_path,
+    AVALON_CONTAINER_ID,
+)
+from openpype.hosts.blender.api import plugin, lib
+from openpype.hosts.blender.api.pipeline import (
+    AVALON_CONTAINERS,
+    AVALON_PROPERTY,
+)
+
+class ImageCameraLoader(plugin.AssetLoader):
+    """Load FBX models.
+
+    Stores the imported asset in an empty named after the asset.
+    """
+
+    families = ["image", "render"]
+    representations = ["*"]
+
+    label = "Load Image in Camera"
+    icon = "code-fork"
+    color = "orange"
+
+    def process_asset(
+        self, context: dict, name: str, namespace: Optional[str] = None,
+        options: Optional[Dict] = None
+    ) -> Optional[List]:
+    
+        """
+        Arguments:
+            name: Use pre-defined name
+            namespace: Use pre-defined namespace
+            context: Full parenthood of representation to load
+            options: Additional settings dictionary
+        """
+        image_filepath = self.filepath_from_context(context)
+        imported_image = bpy.data.images.load(image_filepath)
+
+        camera = bpy.context.scene.camera
+        if not camera:
+            raise ValueError("No camera has been found in scene. Can't import image as camera background.")
+
+        camera.data.show_background_images = True
+        background = camera.data.background_images.new()
+        background.image = imported_image
+
+        self.log.info(f"Image at path {imported_image.filepath} has been correctly loaded in scene as plane.")

--- a/quad_pyblish_module/plugins/blender/load/import_image_sequence.py
+++ b/quad_pyblish_module/plugins/blender/load/import_image_sequence.py
@@ -17,9 +17,9 @@ from openpype.hosts.blender.api.pipeline import (
 )
 
 class ImageSequenceLoader(plugin.AssetLoader):
-    """Load FBX models.
+    """Load Image Sequence in Blender.
 
-    Stores the imported asset in an empty named after the asset.
+    Create background image sequence for active camera and assign selected images.
     """
 
     families = ["image", "render"]
@@ -41,7 +41,6 @@ class ImageSequenceLoader(plugin.AssetLoader):
             context: Full parenthood of representation to load
             options: Additional settings dictionary
         """
-        print(context)
         image_filepath = self.filepath_from_context(context)
         imported_image = bpy.data.images.load(image_filepath)
 

--- a/quad_pyblish_module/plugins/blender/load/import_image_sequence.py
+++ b/quad_pyblish_module/plugins/blender/load/import_image_sequence.py
@@ -23,7 +23,7 @@ class ImageSequenceLoader(plugin.AssetLoader):
     """
 
     families = ["image", "render"]
-    representations = ["*"]
+    representations = ["jpg", "png"]
 
     label = "Load Image Sequence"
     icon = "code-fork"
@@ -55,6 +55,7 @@ class ImageSequenceLoader(plugin.AssetLoader):
         except IndexError:
             background = camera.data.background_images.new()        
         imported_image.source = 'SEQUENCE'
+        background.source = 'IMAGE'
         background.image = imported_image
         background.image_user.frame_duration
 
@@ -71,5 +72,6 @@ class ImageSequenceLoader(plugin.AssetLoader):
         
         background.image_user.frame_start = frame_start
         background.image_user.frame_duration = frames
+        background.image_user.frame_offset = 0
 
         self.log.info(f"Image sequence at path {imported_image.filepath} has been correctly loaded in scene as camera background.")

--- a/quad_pyblish_module/plugins/blender/load/import_video.py
+++ b/quad_pyblish_module/plugins/blender/load/import_video.py
@@ -16,16 +16,16 @@ from openpype.hosts.blender.api.pipeline import (
     AVALON_PROPERTY,
 )
 
-class ImageCameraLoader(plugin.AssetLoader):
+class ImageVideo(plugin.AssetLoader):
     """Load FBX models.
 
     Stores the imported asset in an empty named after the asset.
     """
 
     families = ["image", "render", "review"]
-    representations = ["jpg", "png"]
+    representations = ["mp4", "avi", "h264_mp4"]
 
-    label = "Load Image in Camera"
+    label = "Load Video"
     icon = "code-fork"
     color = "orange"
 
@@ -41,19 +41,20 @@ class ImageCameraLoader(plugin.AssetLoader):
             context: Full parenthood of representation to load
             options: Additional settings dictionary
         """
-        image_filepath = self.filepath_from_context(context)
-        imported_image = bpy.data.images.load(image_filepath)
+        video_filepath = self.filepath_from_context(context)
+        imported_video = bpy.data.movieclips.load(video_filepath)
 
         camera = bpy.context.scene.camera
         if not camera:
-            raise ValueError("No camera has been found in scene. Can't import image as camera background.")
+            raise ValueError("No camera has been found in scene. Can't import video as camera background.")
 
         camera.data.show_background_images = True
         try:
             background = camera.data.background_images[0]
         except IndexError:
-            background = camera.data.background_images.new()        
-        imported_image.source = 'SEQUENCE'
-        background.image = imported_image
+            background = camera.data.background_images.new()
 
-        self.log.info(f"Image at path {imported_image.filepath} has been correctly loaded in scene as camera background.")
+        background.source = 'MOVIE_CLIP'
+        background.clip = imported_video
+
+        self.log.info(f"Video at path {imported_video.filepath} has been correctly loaded in scene as camera background.")

--- a/quad_pyblish_module/plugins/blender/load/import_video.py
+++ b/quad_pyblish_module/plugins/blender/load/import_video.py
@@ -17,9 +17,9 @@ from openpype.hosts.blender.api.pipeline import (
 )
 
 class ImageVideo(plugin.AssetLoader):
-    """Load FBX models.
+    """Load Video in Blender.
 
-    Stores the imported asset in an empty named after the asset.
+    Create background movie clip for active camera and assign selected video.
     """
 
     families = ["image", "render", "review"]


### PR DESCRIPTION
Add 4 differents importer for images and video :
- Import image as reference
- Import image as background image in camera
- Import video
- Import image sequence

These new addons are available in the loader.

fix quadproduction/issues#322