### PR TITLE
#271: enhancement: add format conversion table for after effects renders

### DIFF
--- a/quad_pyblish_module/settings/defaults/project_settings.json
+++ b/quad_pyblish_module/settings/defaults/project_settings.json
@@ -1,5 +1,33 @@
 {
     "project_settings/fix_custom_settings": {
+        "aftereffects": {
+            "publish": {
+                "CollectAERender": {
+                    "format_conversion": [
+                        {
+                            "format": "PNG Sequence",
+                            "converted_label": "png"
+                        },
+                        {
+                            "format": "Photoshop Sequence",
+                            "converted_label": "psd"
+                        },
+                        {
+                            "format": "AVI",
+                            "converted_label": "avi"
+                        },
+                        {
+                            "format": "h.264",
+                            "converted_label": "h264"
+                        },
+                        {
+                            "format": "QuickTime",
+                            "converted_label": "mov"
+                        }
+                    ]
+                }
+            } 
+        },
         "tvpaint": {
             "publish":  {
                 "ExtractPsd":  {

--- a/quad_pyblish_module/settings/schemas/project_schemas/aftereffects.json
+++ b/quad_pyblish_module/settings/schemas/project_schemas/aftereffects.json
@@ -1,0 +1,48 @@
+[
+    {
+        "type": "dict",
+        "key": "aftereffects",
+        "label": "After Effects",
+        "collapsible": true,
+        "children": [
+            {
+                "type": "dict",
+                "key": "publish",
+                "label": "Publish",
+                "collapsible": true,
+                "children": [
+                    {
+                        "type": "dict",
+                        "collapsible": true,
+                        "key": "CollectAERender",
+                        "label": "Collect Render",
+                        "is_group": true,
+                        "children": [
+                            {
+                                "type": "list",
+                                "key": "format_conversion",
+                                "label": "Format names conversion",
+                                "use_label_wrap": true,
+                                "object_type": {
+                                    "type": "dict",
+                                    "children": [
+                                        {
+                                            "type": "text",
+                                            "key": "format",
+                                            "label": "After Effects format"
+                                        },
+                                        {
+                                            "type": "text",
+                                            "key": "converted_label",
+                                            "label": "Converted format label"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/quad_pyblish_module/settings/schemas/project_schemas/main.json
+++ b/quad_pyblish_module/settings/schemas/project_schemas/main.json
@@ -6,6 +6,10 @@
     "children": [
         {
             "type": "template",
+            "name": "fix_custom_settings/aftereffects"
+        },
+        {
+            "type": "template",
             "name": "fix_custom_settings/tvpaint"
         }
     ]


### PR DESCRIPTION
Add settings for format conversion to be used with After Effects render

(linked to https://github.com/quadproduction/OpenPype/pull/642)