### PR TITLE
#355: enhancement: add 'apply_background' option in playblast and pub…

### DIFF
--- a/quad_pyblish_module/plugins/tvpaint/create/create_playblast.py
+++ b/quad_pyblish_module/plugins/tvpaint/create/create_playblast.py
@@ -29,6 +29,7 @@ class TVPaintPlayblastCreator(TVPaintAutoCreator):
         self.default_variant = plugin_settings["default_variant"]
         self.default_variants =  plugin_settings["default_variants"]
         self.extract_psd = plugin_settings["extract_psd"]
+        self.apply_background = False
         self.exports_types = ['camera', 'scene']
         self.export_type = self.exports_types[0]
         self.enabled = plugin_settings.get("enabled", True)
@@ -54,6 +55,7 @@ class TVPaintPlayblastCreator(TVPaintAutoCreator):
             "variant": self.default_variant,
             "creator_attributes": {
                 "mark_for_review": self.mark_for_review,
+                "apply_background": self.apply_background,
                 "export_type": self.export_type,
                 "extract_psd": self.extract_psd
             },
@@ -123,6 +125,11 @@ class TVPaintPlayblastCreator(TVPaintAutoCreator):
                 "mark_for_review",
                 label="Review",
                 default=self.mark_for_review
+            ),
+            BoolDef(
+                "apply_background",
+                label="Apply background color (as defined in settings)",
+                default=self.apply_background
             ),
             BoolDef(
                 "extract_psd",

--- a/quad_pyblish_module/plugins/tvpaint/create/create_publish_layout.py
+++ b/quad_pyblish_module/plugins/tvpaint/create/create_publish_layout.py
@@ -32,6 +32,7 @@ class TVPaintPublishLayoutCreator(TVPaintAutoCreator):
         self.default_variant = plugin_settings["default_variant"]
         self.default_variants = plugin_settings["default_variants"]
         self.extract_psd = plugin_settings["extract_psd"]
+        self.apply_background = False
         self.enabled = plugin_settings.get("enabled", True)
 
     def _create_new_instance(self):
@@ -56,7 +57,8 @@ class TVPaintPublishLayoutCreator(TVPaintAutoCreator):
             "creator_attributes": {
                 "publish_sequence": self.publish_sequence,
                 "keep_layers_transparency": self.keep_layers_transparency,
-                "extract_psd": self.extract_psd
+                "extract_psd": self.extract_psd,
+                "apply_background": self.apply_background,
             },
             "label": self._get_label(subset_name),
             "active": self.active_on_create
@@ -129,6 +131,11 @@ class TVPaintPublishLayoutCreator(TVPaintAutoCreator):
                 "keep_layers_transparency",
                 label="Keep Layers Transparency",
                 default=self.keep_layers_transparency
+            ),
+            BoolDef(
+                "apply_background",
+                label="Apply background color (as defined in settings)",
+                default=self.apply_background
             ),
             BoolDef(
                 "extract_psd",


### PR DESCRIPTION
…lish layout

## Changelog Description
Add new option `Apply background color (as setted in settings)`, disabled by default, which add a background color to the reviews with the color defined in the settings. For subsets which does not implement this option, it is later treated as `True` by default.

**⚠️ Needs to be merge with this other PR :  https://github.com/quadproduction/OpenPype/pull/742**

## Testing notes:
1. Open any tvPaint scene
2. Launch `Publish playblast` or `Publish Layout` subset.