### PR TITLE
#426: enhancement: Ne plus mettre les fentres op en top layer

### DIFF
--- a/quad_pyblish_module/plugins/tvpaint/create/create_playblast.py
+++ b/quad_pyblish_module/plugins/tvpaint/create/create_playblast.py
@@ -29,7 +29,6 @@ class TVPaintPlayblastCreator(TVPaintAutoCreator):
         self.default_variant = plugin_settings["default_variant"]
         self.default_variants =  plugin_settings["default_variants"]
         self.extract_psd = plugin_settings["extract_psd"]
-        self.apply_background = False
         self.exports_types = ['camera', 'scene']
         self.export_type = self.exports_types[0]
         self.enabled = plugin_settings.get("enabled", True)
@@ -55,7 +54,6 @@ class TVPaintPlayblastCreator(TVPaintAutoCreator):
             "variant": self.default_variant,
             "creator_attributes": {
                 "mark_for_review": self.mark_for_review,
-                "apply_background": self.apply_background,
                 "export_type": self.export_type,
                 "extract_psd": self.extract_psd
             },
@@ -125,11 +123,6 @@ class TVPaintPlayblastCreator(TVPaintAutoCreator):
                 "mark_for_review",
                 label="Review",
                 default=self.mark_for_review
-            ),
-            BoolDef(
-                "apply_background",
-                label="Apply background color (as defined in settings)",
-                default=self.apply_background
             ),
             BoolDef(
                 "extract_psd",

--- a/quad_pyblish_module/plugins/tvpaint/create/create_publish_frames.py
+++ b/quad_pyblish_module/plugins/tvpaint/create/create_publish_frames.py
@@ -32,7 +32,6 @@ class TVPaintPublishLayoutCreator(TVPaintAutoCreator):
         self.default_variant = plugin_settings["default_variant"]
         self.default_variants = plugin_settings["default_variants"]
         self.extract_psd = plugin_settings["extract_psd"]
-        self.apply_background = False
         self.enabled = plugin_settings.get("enabled", True)
 
     def _create_new_instance(self):
@@ -57,8 +56,7 @@ class TVPaintPublishLayoutCreator(TVPaintAutoCreator):
             "creator_attributes": {
                 "publish_sequence": self.publish_sequence,
                 "keep_layers_transparency": self.keep_layers_transparency,
-                "extract_psd": self.extract_psd,
-                "apply_background": self.apply_background,
+                "extract_psd": self.extract_psd
             },
             "label": self._get_label(subset_name),
             "active": self.active_on_create
@@ -131,11 +129,6 @@ class TVPaintPublishLayoutCreator(TVPaintAutoCreator):
                 "keep_layers_transparency",
                 label="Keep Layers Transparency",
                 default=self.keep_layers_transparency
-            ),
-            BoolDef(
-                "apply_background",
-                label="Apply background color (as defined in settings)",
-                default=self.apply_background
             ),
             BoolDef(
                 "extract_psd",

--- a/quad_pyblish_module/settings/defaults/project_settings.json
+++ b/quad_pyblish_module/settings/defaults/project_settings.json
@@ -1,105 +1,118 @@
 {
     "project_settings/fix_custom_settings": {
-        "aftereffects": {
-            "publish": {
-                "CollectAERender": {
-                    "format_conversion": [
-                        {
-                            "format": "PNG Sequence",
-                            "converted_label": "png"
-                        },
-                        {
-                            "format": "Photoshop Sequence",
-                            "converted_label": "psd"
-                        },
-                        {
-                            "format": "OpenEXR Sequence",
-                            "converted_label": "exr"
-                        },
-                        {
-                            "format": "AVI",
-                            "converted_label": "avi"
-                        },
-                        {
-                            "format": "h.264",
-                            "converted_label": "h264"
-                        },
-                        {
-                            "format": "QuickTime",
-                            "converted_label": "mov"
-                        }
-                    ]
-                }
-            } 
-        },
-        "tvpaint": {
-            "publish":  {
-                "ExtractPsd":  {
-                    "enabled": false
-                },
-                "ExtractJson":  {
-                    "enabled": false
-                },
-                "IntegrateKitsuSequence":  {
-                    "enabled": false
-                }
-            },
-            "create": {
-                "create_json": {
-                    "enabled": true,
-                    "default_variant": "Main",
-                    "default_variants": []
-                },
-                "create_playblast": {
-                    "enabled": true,
-                    "active_on_create": true,
-                    "mark_for_review": true,
-                    "extract_psd": false,
-                    "default_variant": "Main",
-                    "default_variants": []
-                },
-                "create_publish_layout": {
-                    "enabled": true,
-                    "active_on_create": true,
-                    "keep_layers_transparency": true,
-                    "extract_psd": false,
-                    "default_variant": "Main",
-                    "default_variants": []
-                }
+        "general": {
+            "windows_on_top": {
+                "default": true,
+                "softs": [
+                    {
+                        "applications": [],
+                        "on_top": true
+                    }
+                ]
             }
         },
-        "photoshop": {
-            "groups": {
-                "templates": {
-                    "default": "{group_number:02d}0_{type}",
-                    "overriden": [{"layer_type" : "REF", "template":"XX_{type}"}, {"layer_type" : "UTIL", "template":"XX_{type}"}]
+        "hosts": {
+            "aftereffects": {
+                "publish": {
+                    "CollectAERender": {
+                        "format_conversion": [
+                            {
+                                "format": "PNG Sequence",
+                                "converted_label": "png"
+                            },
+                            {
+                                "format": "Photoshop Sequence",
+                                "converted_label": "psd"
+                            },
+                            {
+                                "format": "OpenEXR Sequence",
+                                "converted_label": "exr"
+                            },
+                            {
+                                "format": "AVI",
+                                "converted_label": "avi"
+                            },
+                            {
+                                "format": "h.264",
+                                "converted_label": "h264"
+                            },
+                            {
+                                "format": "QuickTime",
+                                "converted_label": "mov"
+                            }
+                        ]
+                    }
+                } 
+            },
+            "tvpaint": {
+                "publish":  {
+                    "ExtractPsd":  {
+                        "enabled": false
+                    },
+                    "ExtractJson":  {
+                        "enabled": false
+                    },
+                    "IntegrateKitsuSequence":  {
+                        "enabled": false
+                    }
                 },
-                "expressions": {
-                    "default": "(.+)",
-                    "layer_name": "(.+)",
-                    "type": "(REF|UTIL)",
-                    "group_number": "\\d{2}"
+                "create": {
+                    "create_json": {
+                        "enabled": true,
+                        "default_variant": "Main",
+                        "default_variants": []
+                    },
+                    "create_playblast": {
+                        "enabled": true,
+                        "active_on_create": true,
+                        "mark_for_review": true,
+                        "extract_psd": false,
+                        "default_variant": "Main",
+                        "default_variants": []
+                    },
+                    "create_publish_layout": {
+                        "enabled": true,
+                        "active_on_create": true,
+                        "keep_layers_transparency": true,
+                        "extract_psd": false,
+                        "default_variant": "Main",
+                        "default_variants": []
+                    }
                 }
             },
-            "layers": {
-                "templates": {
-                    "default": "{group_number:02d}0_{layer_number}_{type}_{layer_name}",
-                    "overriden": [{"layer_type" : "REF", "template":"XX_{type}_{layer_name}"}, {"layer_type" : "UTIL", "template":"XX_{type}_{layer_name}"}]
+            "photoshop": {
+                "groups": {
+                    "templates": {
+                        "default": "{group_number:02d}0_{type}",
+                        "overriden": [{"layer_type" : "REF", "template":"XX_{type}"}, {"layer_type" : "UTIL", "template":"XX_{type}"}]
+                    },
+                    "expressions": {
+                        "default": "(.+)",
+                        "layer_name": "(.+)",
+                        "type": "(REF|UTIL)",
+                        "group_number": "\\d{2}"
+                    }
                 },
-                "expressions": {
-                    "default": "(.+)",
-                    "layer_name": "(.+)",
-                    "type": "(CH|BG|PNG|REF|UTIL)",
-                    "group_number": "\\d{2}",
-                    "layer_number": "[a-z]"
+                "layers": {
+                    "templates": {
+                        "default": "{group_number:02d}0_{layer_number}_{type}_{layer_name}",
+                        "overriden": [{"layer_type" : "REF", "template":"XX_{type}_{layer_name}"}, {"layer_type" : "UTIL", "template":"XX_{type}_{layer_name}"}]
+                    },
+                    "expressions": {
+                        "default": "(.+)",
+                        "layer_name": "(.+)",
+                        "type": "(CH|BG|PNG|REF|UTIL)",
+                        "group_number": "\\d{2}",
+                        "layer_number": "[a-z]"
+                    }
+                },
+                "types_colors": {
+                    "red": "CH",
+                    "blue": "BG",
+                    "violet": "PNG",
+                    "yellowColor": "UTIL",
+                    "grain": "REF"
                 }
-            },
-            "types_colors": {
-                "red": "CH",
-                "blue": "BG",
-                "violet": "PNG",
-                "yellowColor": "UTIL",
-                "grain": "REF"
             }
         }
     }

--- a/quad_pyblish_module/settings/defaults/project_settings.json
+++ b/quad_pyblish_module/settings/defaults/project_settings.json
@@ -3,9 +3,9 @@
         "general": {
             "windows_on_top": {
                 "default": true,
-                "softs": [
+                "per_hosts": [
                     {
-                        "applications": [],
+                        "hosts": [],
                         "on_top": true
                     }
                 ]

--- a/quad_pyblish_module/settings/schemas/project_schemas/general.json
+++ b/quad_pyblish_module/settings/schemas/project_schemas/general.json
@@ -16,18 +16,17 @@
             },
             {
                 "type": "list",
-                "key": "softs",
-                "label": "Per softs",
+                "key": "per_hosts",
+                "label": "Per host",
                 "use_label_wrap": true,
                 "object_type": {
                     "type": "dict",
                     "children": [
                         {
-                            "key": "applications",
-                            "label": "Applications",
-                            "type": "apps-enum",
-                            "multiselection": true,
-                            "tooltip": "Applications are not \"live\" and may require to Save and refresh settings UI to update values."
+                            "key": "hosts",
+                            "label": "Hosts",
+                            "type": "hosts-enum",
+                            "multiselection": true
                         },
                         {
                             "type": "boolean",

--- a/quad_pyblish_module/settings/schemas/project_schemas/general.json
+++ b/quad_pyblish_module/settings/schemas/project_schemas/general.json
@@ -1,0 +1,42 @@
+[
+    {
+        "type": "dict",
+        "key": "windows_on_top",
+        "label": "Keep OpenPype's windows on top",
+        "collapsible": true,
+        "children": [
+            {
+                "type": "label",
+                "label": "Only the following hosts are impacted by this feature :<br />Blender, AE, Houdini, Nuke, Nuke X, Photoshop, TvPaint, Maya"
+            },
+            {
+                "type": "boolean",
+                "key": "default",
+                "label": "Default"
+            },
+            {
+                "type": "list",
+                "key": "softs",
+                "label": "Per softs",
+                "use_label_wrap": true,
+                "object_type": {
+                    "type": "dict",
+                    "children": [
+                        {
+                            "key": "applications",
+                            "label": "Applications",
+                            "type": "apps-enum",
+                            "multiselection": true,
+                            "tooltip": "Applications are not \"live\" and may require to Save and refresh settings UI to update values."
+                        },
+                        {
+                            "type": "boolean",
+                            "key": "on_top",
+                            "label": "Keep on top"
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+]

--- a/quad_pyblish_module/settings/schemas/project_schemas/main.json
+++ b/quad_pyblish_module/settings/schemas/project_schemas/main.json
@@ -5,16 +5,38 @@
     "collapsible": true,
     "children": [
         {
-            "type": "template",
-            "name": "fix_custom_settings/aftereffects"
+            "type": "dict",
+            "key": "general",
+            "label": "General",
+            "collapsible": true,
+            "children": [
+                {
+                    "type": "template",
+                    "name": "fix_custom_settings/general"
+                }
+            ]
+
         },
         {
-            "type": "template",
-            "name": "fix_custom_settings/tvpaint"
-        },
-        {
-            "type": "template",
-            "name": "fix_custom_settings/photoshop"
+            "type": "dict",
+            "key": "hosts",
+            "label": "Hosts",
+            "collapsible": true,
+            "children": [
+                {
+                    "type": "template",
+                    "name": "fix_custom_settings/aftereffects"
+                },
+                {
+                    "type": "template",
+                    "name": "fix_custom_settings/tvpaint"
+                },
+                {
+                    "type": "template",
+                    "name": "fix_custom_settings/photoshop"
+                }
+            ]
         }
+        
     ]
 }


### PR DESCRIPTION
Add custom settings to set `on_top` property for qt windows.

⚠️**This PR needs to be merged with this other one : https://github.com/quadproduction/OpenPype/pull/756**