### PR TITLE
521: enhancement: Cropper tous les layers à la taille du canva lors d…

### DIFF
--- a/quad_pyblish_module/plugins/photoshop/publish/auto_crop_to_doc_resolution.py
+++ b/quad_pyblish_module/plugins/photoshop/publish/auto_crop_to_doc_resolution.py
@@ -1,0 +1,33 @@
+import pyblish.api
+from openpype.pipeline.publish import (
+    ValidateContentsOrder,
+    PublishXmlValidationError,
+    OptionalPyblishPluginMixin
+)
+from openpype.hosts.photoshop import api as photoshop
+
+
+class autoCropToDocResolution(
+        OptionalPyblishPluginMixin,
+        pyblish.api.ContextPlugin
+    ):
+    """Crop all the layers to fit the doc resolution
+    """
+
+    label = "AutoCrop To Canva"
+    hosts = ["photoshop"]
+    order = pyblish.api.ExtractorOrder - 0.49
+    families = ["image"]
+    optional = True
+    active = False
+
+    def process(self, context):
+
+        if not self.is_active(context.data):
+            return
+
+        stub = photoshop.stub()
+        
+        docResolution = stub.get_activeDocument_format_resolution()
+        stub.crop_document_to_coordinate(0, 0, docResolution["width"], docResolution['height'])
+

--- a/quad_pyblish_module/plugins/photoshop/publish/auto_crop_to_doc_resolution.py
+++ b/quad_pyblish_module/plugins/photoshop/publish/auto_crop_to_doc_resolution.py
@@ -29,5 +29,7 @@ class autoCropToDocResolution(
         stub = photoshop.stub()
         
         docResolution = stub.get_activeDocument_format_resolution()
+        if not docResolution:
+            return
         stub.crop_document_to_coordinate(0, 0, docResolution["width"], docResolution['height'])
 


### PR DESCRIPTION
…u publish

Fix quadproduction/issues#521

Ajoute une étape dans les extracts de crop des layer avant d'exporter.
Cela est fait apres avoir save la scène avant les exports, de telle manière que la v+1 est croppé mais pas le fichier depuis lequel on a effectué le publish